### PR TITLE
fix XAmzContentSHA256Mismatch error

### DIFF
--- a/upload/handler.go
+++ b/upload/handler.go
@@ -181,6 +181,7 @@ func NewHandler(conf *conf.S3ndConf) *S3ndHandler {
 		context.TODO(),
 		config.WithBaseEndpoint(*conf.EndpointUrl),
 		config.WithHTTPClient(httpClient),
+		config.WithRequestChecksumCalculation(aws.RequestChecksumCalculationWhenRequired),
 	)
 	if err != nil {
 		logger.Error(err.Error())


### PR DESCRIPTION
https://github.com/lsst-dm/s3nd/pull/15 updated aws-sdk-go-v2 and introduced these API errors with Ceph RGW:

    api error XAmzContentSHA256Mismatch: UnknownError