### PR TITLE
add transfer duration & size histogram metrics

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -267,11 +267,8 @@ const docTemplate = `{
                             "type": "string",
                             "example": "37.921µs"
                         },
-                        "duration_seconds": {
-                            "type": "number",
-                            "example": 0.021
-                        },
                         "file": {
+                            "description": "request input",
                             "type": "string",
                             "example": "/path/to/file.txt"
                         },
@@ -279,29 +276,51 @@ const docTemplate = `{
                             "type": "string",
                             "format": "uuid"
                         },
-                        "size_bytes": {
-                            "type": "integer",
-                            "example": 1000
-                        },
                         "slug": {
-                            "description": "for logging",
+                            "description": "request input; for logging",
                             "type": "string",
                             "example": "Gray Garden Slug"
                         },
-                        "transfer_rate": {
-                            "description": "human friendly",
-                            "type": "string",
-                            "example": "1000B/s"
-                        },
-                        "transfer_rate_mbits": {
-                            "type": "number",
-                            "example": 0.001
+                        "upload_attempts": {
+                            "type": "integer",
+                            "example": 1
                         },
                         "upload_parts": {
                             "type": "integer",
                             "example": 1
                         },
+                        "upload_queued_seconds": {
+                            "type": "number",
+                            "example": 0.021
+                        },
+                        "upload_rate": {
+                            "description": "human friendly",
+                            "type": "string",
+                            "example": "42Mbit/s"
+                        },
+                        "upload_rate_bytes": {
+                            "type": "number",
+                            "example": 796.178343
+                        },
+                        "upload_size_bytes": {
+                            "type": "integer",
+                            "example": 1000
+                        },
+                        "upload_total": {
+                            "description": "human friendly",
+                            "type": "string",
+                            "example": "21.916462ms"
+                        },
+                        "upload_total_seconds": {
+                            "type": "number",
+                            "example": 1.255
+                        },
+                        "upload_transfer_seconds": {
+                            "type": "number",
+                            "example": 1.234
+                        },
                         "uri": {
+                            "description": "request input",
                             "type": "string",
                             "example": "s3://my-bucket/my-key"
                         }
@@ -351,20 +370,8 @@ const docTemplate = `{
         "task": {
             "type": "object",
             "properties": {
-                "attempts": {
-                    "type": "integer",
-                    "example": 1
-                },
-                "duration": {
-                    "description": "human friendly",
-                    "type": "string",
-                    "example": "21.916462ms"
-                },
-                "duration_seconds": {
-                    "type": "number",
-                    "example": 0.021
-                },
                 "file": {
+                    "description": "request input",
                     "type": "string",
                     "example": "/path/to/file.txt"
                 },
@@ -372,29 +379,51 @@ const docTemplate = `{
                     "type": "string",
                     "format": "uuid"
                 },
-                "size_bytes": {
-                    "type": "integer",
-                    "example": 1000
-                },
                 "slug": {
-                    "description": "for logging",
+                    "description": "request input; for logging",
                     "type": "string",
                     "example": "Gray Garden Slug"
                 },
-                "transfer_rate": {
-                    "description": "human friendly",
-                    "type": "string",
-                    "example": "1000B/s"
-                },
-                "transfer_rate_mbits": {
-                    "type": "number",
-                    "example": 0.001
+                "upload_attempts": {
+                    "type": "integer",
+                    "example": 1
                 },
                 "upload_parts": {
                     "type": "integer",
                     "example": 1
                 },
+                "upload_queued_seconds": {
+                    "type": "number",
+                    "example": 0.021
+                },
+                "upload_rate": {
+                    "description": "human friendly",
+                    "type": "string",
+                    "example": "42Mbit/s"
+                },
+                "upload_rate_bytes": {
+                    "type": "number",
+                    "example": 796.178343
+                },
+                "upload_size_bytes": {
+                    "type": "integer",
+                    "example": 1000
+                },
+                "upload_total": {
+                    "description": "human friendly",
+                    "type": "string",
+                    "example": "21.916462ms"
+                },
+                "upload_total_seconds": {
+                    "type": "number",
+                    "example": 1.255
+                },
+                "upload_transfer_seconds": {
+                    "type": "number",
+                    "example": 1.234
+                },
                 "uri": {
+                    "description": "request input",
                     "type": "string",
                     "example": "s3://my-bucket/my-key"
                 }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -258,11 +258,8 @@
                             "type": "string",
                             "example": "37.921µs"
                         },
-                        "duration_seconds": {
-                            "type": "number",
-                            "example": 0.021
-                        },
                         "file": {
+                            "description": "request input",
                             "type": "string",
                             "example": "/path/to/file.txt"
                         },
@@ -270,29 +267,51 @@
                             "type": "string",
                             "format": "uuid"
                         },
-                        "size_bytes": {
-                            "type": "integer",
-                            "example": 1000
-                        },
                         "slug": {
-                            "description": "for logging",
+                            "description": "request input; for logging",
                             "type": "string",
                             "example": "Gray Garden Slug"
                         },
-                        "transfer_rate": {
-                            "description": "human friendly",
-                            "type": "string",
-                            "example": "1000B/s"
-                        },
-                        "transfer_rate_mbits": {
-                            "type": "number",
-                            "example": 0.001
+                        "upload_attempts": {
+                            "type": "integer",
+                            "example": 1
                         },
                         "upload_parts": {
                             "type": "integer",
                             "example": 1
                         },
+                        "upload_queued_seconds": {
+                            "type": "number",
+                            "example": 0.021
+                        },
+                        "upload_rate": {
+                            "description": "human friendly",
+                            "type": "string",
+                            "example": "42Mbit/s"
+                        },
+                        "upload_rate_bytes": {
+                            "type": "number",
+                            "example": 796.178343
+                        },
+                        "upload_size_bytes": {
+                            "type": "integer",
+                            "example": 1000
+                        },
+                        "upload_total": {
+                            "description": "human friendly",
+                            "type": "string",
+                            "example": "21.916462ms"
+                        },
+                        "upload_total_seconds": {
+                            "type": "number",
+                            "example": 1.255
+                        },
+                        "upload_transfer_seconds": {
+                            "type": "number",
+                            "example": 1.234
+                        },
                         "uri": {
+                            "description": "request input",
                             "type": "string",
                             "example": "s3://my-bucket/my-key"
                         }
@@ -342,20 +361,8 @@
         "task": {
             "type": "object",
             "properties": {
-                "attempts": {
-                    "type": "integer",
-                    "example": 1
-                },
-                "duration": {
-                    "description": "human friendly",
-                    "type": "string",
-                    "example": "21.916462ms"
-                },
-                "duration_seconds": {
-                    "type": "number",
-                    "example": 0.021
-                },
                 "file": {
+                    "description": "request input",
                     "type": "string",
                     "example": "/path/to/file.txt"
                 },
@@ -363,29 +370,51 @@
                     "type": "string",
                     "format": "uuid"
                 },
-                "size_bytes": {
-                    "type": "integer",
-                    "example": 1000
-                },
                 "slug": {
-                    "description": "for logging",
+                    "description": "request input; for logging",
                     "type": "string",
                     "example": "Gray Garden Slug"
                 },
-                "transfer_rate": {
-                    "description": "human friendly",
-                    "type": "string",
-                    "example": "1000B/s"
-                },
-                "transfer_rate_mbits": {
-                    "type": "number",
-                    "example": 0.001
+                "upload_attempts": {
+                    "type": "integer",
+                    "example": 1
                 },
                 "upload_parts": {
                     "type": "integer",
                     "example": 1
                 },
+                "upload_queued_seconds": {
+                    "type": "number",
+                    "example": 0.021
+                },
+                "upload_rate": {
+                    "description": "human friendly",
+                    "type": "string",
+                    "example": "42Mbit/s"
+                },
+                "upload_rate_bytes": {
+                    "type": "number",
+                    "example": 796.178343
+                },
+                "upload_size_bytes": {
+                    "type": "integer",
+                    "example": 1000
+                },
+                "upload_total": {
+                    "description": "human friendly",
+                    "type": "string",
+                    "example": "21.916462ms"
+                },
+                "upload_total_seconds": {
+                    "type": "number",
+                    "example": 1.255
+                },
+                "upload_transfer_seconds": {
+                    "type": "number",
+                    "example": 1.234
+                },
                 "uri": {
+                    "description": "request input",
                     "type": "string",
                     "example": "s3://my-bucket/my-key"
                 }

--- a/docs/swagger.md
+++ b/docs/swagger.md
@@ -330,15 +330,19 @@ Status: Gateway Timeout
 |------|------|---------|:--------:| ------- |-------------|---------|
 | attempts | integer| `int64` |  | |  | `5` |
 | duration | string| `string` |  | |  | `37.921µs` |
-| duration_seconds | number| `float64` |  | |  | `0.021` |
-| file | string| `string` |  | |  | `/path/to/file.txt` |
+| file | string| `string` |  | | request input | `/path/to/file.txt` |
 | id | uuid (formatted string)| `strfmt.UUID` |  | |  |  |
-| size_bytes | integer| `int64` |  | |  | `1000` |
-| slug | string| `string` |  | | for logging | `Gray Garden Slug` |
-| transfer_rate | string| `string` |  | | human friendly | `1000B/s` |
-| transfer_rate_mbits | number| `float64` |  | |  | `0.001` |
+| slug | string| `string` |  | | request input; for logging | `Gray Garden Slug` |
+| upload_attempts | integer| `int64` |  | |  | `1` |
 | upload_parts | integer| `int64` |  | |  | `1` |
-| uri | string| `string` |  | |  | `s3://my-bucket/my-key` |
+| upload_queued_seconds | number| `float64` |  | |  | `0.021` |
+| upload_rate | string| `string` |  | | human friendly | `42Mbit/s` |
+| upload_rate_bytes | number| `float64` |  | |  | `796.178343` |
+| upload_size_bytes | integer| `int64` |  | |  | `1000` |
+| upload_total | string| `string` |  | | human friendly | `21.916462ms` |
+| upload_total_seconds | number| `float64` |  | |  | `1.255` |
+| upload_transfer_seconds | number| `float64` |  | |  | `1.234` |
+| uri | string| `string` |  | | request input | `s3://my-bucket/my-key` |
 
 
 
@@ -391,16 +395,18 @@ Status: Gateway Timeout
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| attempts | integer| `int64` |  | |  | `1` |
-| duration | string| `string` |  | | human friendly | `21.916462ms` |
-| duration_seconds | number| `float64` |  | |  | `0.021` |
-| file | string| `string` |  | |  | `/path/to/file.txt` |
+| file | string| `string` |  | | request input | `/path/to/file.txt` |
 | id | uuid (formatted string)| `strfmt.UUID` |  | |  |  |
-| size_bytes | integer| `int64` |  | |  | `1000` |
-| slug | string| `string` |  | | for logging | `Gray Garden Slug` |
-| transfer_rate | string| `string` |  | | human friendly | `1000B/s` |
-| transfer_rate_mbits | number| `float64` |  | |  | `0.001` |
+| slug | string| `string` |  | | request input; for logging | `Gray Garden Slug` |
+| upload_attempts | integer| `int64` |  | |  | `1` |
 | upload_parts | integer| `int64` |  | |  | `1` |
-| uri | string| `string` |  | |  | `s3://my-bucket/my-key` |
+| upload_queued_seconds | number| `float64` |  | |  | `0.021` |
+| upload_rate | string| `string` |  | | human friendly | `42Mbit/s` |
+| upload_rate_bytes | number| `float64` |  | |  | `796.178343` |
+| upload_size_bytes | integer| `int64` |  | |  | `1000` |
+| upload_total | string| `string` |  | | human friendly | `21.916462ms` |
+| upload_total_seconds | number| `float64` |  | |  | `1.255` |
+| upload_transfer_seconds | number| `float64` |  | |  | `1.234` |
+| uri | string| `string` |  | | request input | `s3://my-bucket/my-key` |
 
 

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -83,33 +83,48 @@ definitions:
           duration:
             example: 37.921µs
             type: string
-          duration_seconds:
-            example: 0.021
-            type: number
           file:
+            description: request input
             example: /path/to/file.txt
             type: string
           id:
             format: uuid
             type: string
-          size_bytes:
-            example: 1000
-            type: integer
           slug:
-            description: for logging
+            description: request input; for logging
             example: Gray Garden Slug
             type: string
-          transfer_rate:
-            description: human friendly
-            example: 1000B/s
-            type: string
-          transfer_rate_mbits:
-            example: 0.001
-            type: number
+          upload_attempts:
+            example: 1
+            type: integer
           upload_parts:
             example: 1
             type: integer
+          upload_queued_seconds:
+            example: 0.021
+            type: number
+          upload_rate:
+            description: human friendly
+            example: 42Mbit/s
+            type: string
+          upload_rate_bytes:
+            example: 796.178343
+            type: number
+          upload_size_bytes:
+            example: 1000
+            type: integer
+          upload_total:
+            description: human friendly
+            example: 21.916462ms
+            type: string
+          upload_total_seconds:
+            example: 1.255
+            type: number
+          upload_transfer_seconds:
+            example: 1.234
+            type: number
           uri:
+            description: request input
             example: s3://my-bucket/my-key
             type: string
         type: object
@@ -144,40 +159,48 @@ definitions:
     type: object
   task:
     properties:
-      attempts:
-        example: 1
-        type: integer
-      duration:
-        description: human friendly
-        example: 21.916462ms
-        type: string
-      duration_seconds:
-        example: 0.021
-        type: number
       file:
+        description: request input
         example: /path/to/file.txt
         type: string
       id:
         format: uuid
         type: string
-      size_bytes:
-        example: 1000
-        type: integer
       slug:
-        description: for logging
+        description: request input; for logging
         example: Gray Garden Slug
         type: string
-      transfer_rate:
-        description: human friendly
-        example: 1000B/s
-        type: string
-      transfer_rate_mbits:
-        example: 0.001
-        type: number
+      upload_attempts:
+        example: 1
+        type: integer
       upload_parts:
         example: 1
         type: integer
+      upload_queued_seconds:
+        example: 0.021
+        type: number
+      upload_rate:
+        description: human friendly
+        example: 42Mbit/s
+        type: string
+      upload_rate_bytes:
+        example: 796.178343
+        type: number
+      upload_size_bytes:
+        example: 1000
+        type: integer
+      upload_total:
+        description: human friendly
+        example: 21.916462ms
+        type: string
+      upload_total_seconds:
+        example: 1.255
+        type: number
+      upload_transfer_seconds:
+        example: 1.234
+        type: number
       uri:
+        description: request input
         example: s3://my-bucket/my-key
         type: string
     type: object

--- a/test/metrics_test.go
+++ b/test/metrics_test.go
@@ -1,14 +1,52 @@
 package s3nd_test
 
 import (
+	"context"
 	"io"
 	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/lsst-dm/deliverator/client"
+	"github.com/lsst-dm/deliverator/upload"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("GET /metrics", func() {
+	BeforeEach(func() {
+		// Make a request to ensure we have some metrics.
+		// In particular we want to ensure we have some histogram metrics.
+		var status *upload.RequestStatus
+		var uri url.URL
+		var file string
+		slug := "banana"
+		testFile := "test2"
+
+		f, err := os.CreateTemp("", testFile)
+		Expect(err).NotTo(HaveOccurred())
+		defer os.Remove(f.Name())
+		defer f.Close()
+		for i := 0; i < 3; i++ {
+			_, err = f.WriteString(testFile + "\n")
+			Expect(err).NotTo(HaveOccurred())
+		}
+		_ = f.Sync()
+
+		s3nd := client.NewClient(s3ndUrl)
+		file = f.Name()
+		uri = url.URL{
+			Scheme: "s3",
+			Host:   s3ndBucket,
+			Path:   "/" + testFile,
+		}
+
+		status, err = s3nd.Upload(context.Background(), file, uri, slug)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status.Code).To(Equal(http.StatusOK))
+	})
+
 	It("returns 200", func() {
 		resp, err := http.Get(s3ndUrl.String() + "/metrics")
 		Expect(err).NotTo(HaveOccurred())
@@ -16,8 +54,26 @@ var _ = Describe("GET /metrics", func() {
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 		body, _ := io.ReadAll(resp.Body)
+
 		Expect(string(body)).To(ContainSubstring("s3nd_upload_valid_requests_total"))
 		Expect(string(body)).To(ContainSubstring("s3nd_upload_parts_active"))
 		Expect(string(body)).To(ContainSubstring("s3nd_s3_tcp_conn_pace_max_bytes"))
+
+		// Check for histogram metrics
+		// note that these are native Prometheus histogram metrics which use protobufs
+		// The "classic" text format is being checked here for convenience
+		histogramMetrics := []string{
+			"s3nd_upload_total_seconds",
+			"s3nd_upload_queued_seconds",
+			"s3nd_upload_transfer_seconds",
+			"s3nd_upload_transfer_rate_bytes",
+			"s3nd_upload_transfer_size_bytes",
+		}
+
+		for _, m := range histogramMetrics {
+			Expect(string(body)).To(ContainSubstring(m + "_count"))
+			Expect(string(body)).To(ContainSubstring(m + "_sum"))
+			Expect(string(body)).To(ContainSubstring(m + "_bucket"))
+		}
 	})
 })

--- a/test/upload_test.go
+++ b/test/upload_test.go
@@ -257,19 +257,17 @@ var _ = Describe("client.Upload", func() {
 		task := status.Task
 		Expect(task.Id).ToNot(BeEmpty())
 		Expect(task.Uri).To(Equal(&upload.RequestURL{URL: uri}))
-		Expect(task.Bucket).To(BeNil()) // unset
-		Expect(task.Key).To(BeNil())    // unset
 		Expect(task.File).To(Equal(&file))
-		Expect(task.StartTime.IsZero()).To(BeTrue()) // unset
-		Expect(task.EndTime.IsZero()).To(BeTrue())   // unset
-		Expect(task.Duration).ToNot(BeEmpty())
-		Expect(task.DurationSeconds).ToNot(BeZero())
-		Expect(task.Attempts).To(Equal(1))
-		Expect(task.SizeBytes).ToNot(BeZero())
-		Expect(task.UploadParts).To(Equal(int64(1)))
-		Expect(task.TransferRate).ToNot(BeEmpty())
-		Expect(task.TransferRateMbits).ToNot(BeZero())
 		Expect(task.Slug).To(Equal(&slug))
+		Expect(task.UploadTotal).ToNot(BeEmpty()) // human friendly
+		Expect(task.UploadTotalSeconds).ToNot(BeZero())
+		Expect(task.UploadQueuedSeconds).To(BeZero())
+		Expect(task.UploadTransferSeconds).ToNot(BeZero())
+		Expect(task.UploadAttempts).To(Equal(1))
+		Expect(task.UploadSizeBytes).ToNot(BeZero())
+		Expect(task.UploadParts).To(Equal(int64(1)))
+		Expect(task.UploadTransferRate).ToNot(BeEmpty()) // human friendly
+		Expect(task.UploadTransferRateBytes).ToNot(BeZero())
 	})
 })
 
@@ -335,19 +333,17 @@ var _ = Describe("client.UploadMulti", func() {
 			task := uStatus.RequestStatus.Task
 			Expect(task.Id).ToNot(BeEmpty())
 			Expect(task.Uri).ToNot(BeNil())
-			Expect(task.Bucket).To(BeNil()) // unset
-			Expect(task.Key).To(BeNil())    // unset
 			Expect(task.File).ToNot(BeNil())
-			Expect(task.StartTime).To(Equal(time.Time{})) // unset
-			Expect(task.EndTime).To(Equal(time.Time{}))   // unset
-			Expect(task.Duration).ToNot(BeEmpty())
-			Expect(task.DurationSeconds).ToNot(BeZero())
-			Expect(task.Attempts).To(Equal(1))
-			Expect(task.SizeBytes).ToNot(BeZero())
-			Expect(task.UploadParts).To(Equal(int64(1)))
-			Expect(task.TransferRate).ToNot(BeEmpty())
-			Expect(task.TransferRateMbits).ToNot(BeZero())
 			Expect(task.Slug).To(Equal(&slug))
+			Expect(task.UploadTotal).ToNot(BeEmpty()) // human friendly
+			Expect(task.UploadTotalSeconds).ToNot(BeZero())
+			Expect(task.UploadQueuedSeconds).To(BeZero())
+			Expect(task.UploadTransferSeconds).ToNot(BeZero())
+			Expect(task.UploadAttempts).To(Equal(1))
+			Expect(task.UploadSizeBytes).ToNot(BeZero())
+			Expect(task.UploadParts).To(Equal(int64(1)))
+			Expect(task.UploadTransferRate).ToNot(BeEmpty()) // human friendly
+			Expect(task.UploadTransferRateBytes).ToNot(BeZero())
 		}
 	})
 })


### PR DESCRIPTION
New histogram metrics:
- s3nd_upload_total_seconds
- s3nd_upload_queued_seconds
- s3nd_upload_transfer_seconds
- s3nd_upload_transfer_rate_bytes
- s3nd_upload_transfer_size_bytes

+ normalize metric variable names
+ normalize serialization of upload.UploadTask field names to be more
  consistent with metric names.

The changes to upload.UploadTask constitute a breaking change.