### PR TITLE
add S3ND_UPLOAD_TIMEOUT_FACTOR

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,17 +119,21 @@ Usage of ./s3nd:
   -queue-timeout string
     	Queue Timeout waiting for transfer to start (S3ND_QUEUE_TIMEOUT) (default "10s")
   -upload-bwlimit string
-    	Upload bandwidth limit in bits per second (S3ND_UPLOAD_BWLIMIT) (default "0")
+    	Upload aggregate bandwidth limit in bits per second (S3ND_UPLOAD_BWLIMIT) (default "0")
   -upload-max-parallel int
     	Maximum number of parallel object uploads (S3ND_UPLOAD_MAX_PARALLEL) (default 100)
   -upload-partsize string
     	Upload Part Size (S3ND_UPLOAD_PARTSIZE) (default "5Mi")
   -upload-timeout string
     	Upload Timeout (S3ND_UPLOAD_TIMEOUT) (default "10s")
+  -upload-timeout-factor int
+    	Upload Timeout exponential backoff base (S3ND_UPLOAD_TIMEOUT_FACTOR) (default 1)
   -upload-tries int
     	Max number of upload tries (S3ND_UPLOAD_TRIES) (default 1)
   -upload-write-buffer-size string
     	Upload Write Buffer Size (S3ND_UPLOAD_WRITE_BUFFER_SIZE) (default "64Ki")
+  -version
+    	print version and exit
 ```
 
 ### `AWS_ACCESS_KEY_ID`
@@ -211,6 +215,19 @@ S3ND_UPLOAD_TRIES="10"
 ```
 
 Could result up in to 30s elapsing before a transfer is reported as failed.
+
+### `S3ND_UPLOAD_TIMEOUT_FACTOR`
+
+When set to a value other than one, enables exponential upload retry timeout duration backoff.
+
+E.g.
+```
+S3ND_UPLOAD_TIMEOUT="5s"
+S3ND_UPLOAD_TIMEOUT_FACTOR="2"
+S3ND_UPLOAD_TRIES="3"
+```
+
+Would result in attempt timeouts of 5s, 10s, and 20s.
 
 ### `S3ND_UPLOAD_TRIES`
 

--- a/cmd/s3nd/main.go
+++ b/cmd/s3nd/main.go
@@ -38,18 +38,19 @@ func main() {
 	// set the version displayed in the swagger UI.
 	docs.SwaggerInfo.Version = version.Version
 
-	conf := conf.NewConf(version.Version)
+	conf := conf.NewS3ndConf(version.Version)
 
+	slog.Info("service configuration", "conf", conf.ToMap())
 	slog.Info("starting s3nd", "version", version.Version)
 
-	uHandler := upload.NewS3ndHandler(&conf)
+	uHandler := upload.NewS3ndHandler(conf)
 
 	reg := prometheus.NewRegistry()
 	reg.MustRegister(collector.NewS3ndCollector(uHandler))
 
 	r := chi.NewRouter()
 	r.Get("/swagger/*", httpSwagger.Handler())
-	r.Handle("/version", version.NewHandler(&conf))
+	r.Handle("/version", version.NewHandler(conf))
 	r.Handle("/upload", uHandler)
 	r.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
 

--- a/conf/conf_test.go
+++ b/conf/conf_test.go
@@ -1,6 +1,9 @@
 package conf_test
 
 import (
+	"flag"
+	"os"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -9,7 +12,7 @@ import (
 	k8sresource "k8s.io/apimachinery/pkg/api/resource"
 )
 
-var _ = Describe("Conf", func() {
+var _ = Describe("S3ndConf", func() {
 	Describe("UploadBwlimitBytes()", func() {
 		It("should return bytes instead of bits", func() {
 			limit, _ := k8sresource.ParseQuantity("1Ki")
@@ -18,6 +21,42 @@ var _ = Describe("Conf", func() {
 			}
 
 			Expect(conf.UploadBwlimitBytes()).To(Equal(int64(128)))
+		})
+	})
+
+	Describe("NewConf()", func() {
+		BeforeEach(func() {
+			os.Clearenv()
+
+			// required env var for NewConf to succeed
+			err := os.Setenv("S3ND_ENDPOINT_URL", "http://example.com")
+			Expect(err).ToNot(HaveOccurred())
+
+			// prevent testing flags from being visible, E.g. `-test.timeout`
+			os.Args = []string{"s3nd"}
+
+			// reset flag set to prevent flag redefined panic
+			flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+		})
+		AfterEach(func() {
+			os.Clearenv()
+		})
+
+		Describe("S3ND_UPLOAD_TIMEOUT_FACTOR", func() {
+			It("should default to 1", func() {
+				conf := conf.NewS3ndConf("1.2.3")
+
+				Expect(conf.UploadTimeoutFactor()).To(Equal(1))
+			})
+
+			It("should read from env", func() {
+				err := os.Setenv("S3ND_UPLOAD_TIMEOUT_FACTOR", "2")
+				Expect(err).ToNot(HaveOccurred())
+
+				conf := conf.NewS3ndConf("1.2.3")
+
+				Expect(conf.UploadTimeoutFactor()).To(Equal(2))
+			})
 		})
 	})
 })

--- a/upload/handler_test.go
+++ b/upload/handler_test.go
@@ -1,0 +1,94 @@
+package upload_test
+
+import (
+	"flag"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/lsst-dm/deliverator/v2/conf"
+	"github.com/lsst-dm/deliverator/v2/upload"
+)
+
+var _ = Describe("S3ndHandler", func() {
+	BeforeEach(func() {
+		os.Clearenv()
+
+		// required env var for NewConf to succeed
+		err := os.Setenv("S3ND_ENDPOINT_URL", "http://example.com")
+		Expect(err).ToNot(HaveOccurred())
+
+		// prevent testing flags from being visible, E.g. `-test.timeout`
+		os.Args = []string{"s3nd"}
+
+		// reset flag set to prevent flag redefined panic
+		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	})
+	AfterEach(func() {
+		os.Clearenv()
+	})
+
+	Describe("uploadTimeout()", func() {
+		Context("when factor is 1", func() {
+			BeforeEach(func() {
+				err := os.Setenv("S3ND_UPLOAD_TIMEOUT", "5s")
+				Expect(err).ToNot(HaveOccurred())
+				err = os.Setenv("S3ND_UPLOAD_TIMEOUT_FACTOR", "1")
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("1st upload attempt", func() {
+				It("should return 1x", func() {
+					h := upload.NewS3ndHandler(conf.NewS3ndConf("1.2.3"))
+					Expect(h.UploadTimeout(1)).To(Equal(time.Duration(5 * time.Second)))
+				})
+			})
+
+			Context("2nd upload attempt", func() {
+				It("should return 1x", func() {
+					h := upload.NewS3ndHandler(conf.NewS3ndConf("1.2.3"))
+					Expect(h.UploadTimeout(2)).To(Equal(time.Duration(5 * time.Second)))
+				})
+			})
+
+			Context("3rd upload attempt", func() {
+				It("should return 1x", func() {
+					h := upload.NewS3ndHandler(conf.NewS3ndConf("1.2.3"))
+					Expect(h.UploadTimeout(3)).To(Equal(time.Duration(5 * time.Second)))
+				})
+			})
+		})
+
+		Context("when factor is 2", func() {
+			BeforeEach(func() {
+				err := os.Setenv("S3ND_UPLOAD_TIMEOUT", "5s")
+				Expect(err).ToNot(HaveOccurred())
+				err = os.Setenv("S3ND_UPLOAD_TIMEOUT_FACTOR", "2")
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("1st upload attempt", func() {
+				It("should return 1x", func() {
+					h := upload.NewS3ndHandler(conf.NewS3ndConf("1.2.3"))
+					Expect(h.UploadTimeout(1)).To(Equal(time.Duration(5 * time.Second)))
+				})
+			})
+
+			Context("2nd upload attempt", func() {
+				It("should return 2x", func() {
+					h := upload.NewS3ndHandler(conf.NewS3ndConf("1.2.3"))
+					Expect(h.UploadTimeout(2)).To(Equal(time.Duration(10 * time.Second)))
+				})
+			})
+
+			Context("3rd upload attempt", func() {
+				It("should return 4x", func() {
+					h := upload.NewS3ndHandler(conf.NewS3ndConf("1.2.3"))
+					Expect(h.UploadTimeout(3)).To(Equal(time.Duration(20 * time.Second)))
+				})
+			})
+		})
+	})
+})


### PR DESCRIPTION
When set to a value other than one, enables exponential upload retry timeout duration backoff.

E.g.
```
S3ND_UPLOAD_TIMEOUT="5s"
S3ND_UPLOAD_TIMEOUT_FACTOR="2"
S3ND_UPLOAD_TRIES="3"
```

Would result in attempt timeouts of 5s, 10s, and 20s.